### PR TITLE
Add local event submission workflow and admin dashboard

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin Dashboard | Boston Black Events Guide</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <div class="container">
+            <h1>Admin Dashboard</h1>
+            <p class="subtitle">Review and manage submitted events</p>
+        </div>
+    </header>
+
+    <div class="container">
+        <div class="notice-card">
+            <h2>Pending submissions</h2>
+            <p>These events were submitted from the public form and saved to this browser. Use the controls below to copy the
+                event data, mark items as reviewed, or export everything as JSON for publishing.</p>
+        </div>
+
+        <div class="admin-actions">
+            <button id="exportEvents" type="button">Export all to JSON</button>
+            <a class="secondary-link" href="submit-event.html">Back to submission form</a>
+        </div>
+
+        <section id="pendingContainer" class="pending-events" aria-live="polite">
+            <p class="empty-state">No pending submissions yet. Invite community members to share their events!</p>
+        </section>
+    </div>
+
+    <footer>
+        <div class="container">
+            <p>© 2025 Boston Black Events Guide | <a href="index.html">Home</a> | <a href="submit-event.html">Submit an Event</a></p>
+        </div>
+    </footer>
+
+    <template id="pendingEventTemplate">
+        <article class="pending-event">
+            <div class="pending-event__summary">
+                <h3 class="pending-event__title"></h3>
+                <dl>
+                    <div><dt>Date &amp; Time:</dt><dd data-field="display_date"></dd></div>
+                    <div><dt>Venue:</dt><dd data-field="venue"></dd></div>
+                    <div><dt>Category:</dt><dd data-field="category"></dd></div>
+                    <div><dt>Summary:</dt><dd data-field="summary"></dd></div>
+                </dl>
+            </div>
+            <div class="pending-event__details">
+                <p data-field="description"></p>
+                <p class="pending-event__meta">Submitted <span data-field="submitted_at"></span> · <span data-field="price"></span></p>
+                <div class="pending-event__actions">
+                    <button data-action="copy" type="button">Copy JSON</button>
+                    <a data-action="open" class="secondary-link" target="_blank" rel="noopener">View event link</a>
+                    <button data-action="reviewed" type="button" class="danger">Mark as reviewed</button>
+                </div>
+            </div>
+        </article>
+    </template>
+
+    <script>
+        const storageKey = "pendingEvents";
+        const pendingContainer = document.getElementById("pendingContainer");
+        const exportButton = document.getElementById("exportEvents");
+        const template = document.getElementById("pendingEventTemplate");
+
+        function readPendingEvents() {
+            try {
+                const stored = localStorage.getItem(storageKey);
+                return stored ? JSON.parse(stored) : [];
+            } catch (error) {
+                console.error("Unable to parse pending events", error);
+                return [];
+            }
+        }
+
+        function writePendingEvents(events) {
+            localStorage.setItem(storageKey, JSON.stringify(events));
+        }
+
+        function formatDate(isoString) {
+            try {
+                const date = new Date(isoString);
+                if (Number.isNaN(date.valueOf())) {
+                    return "Unknown";
+                }
+                return date.toLocaleString();
+            } catch (error) {
+                return "Unknown";
+            }
+        }
+
+        function renderEmptyState() {
+            pendingContainer.innerHTML = "";
+            const message = document.createElement("p");
+            message.className = "empty-state";
+            message.textContent = "No pending submissions yet. Invite community members to share their events!";
+            pendingContainer.appendChild(message);
+        }
+
+        function renderPendingEvents() {
+            const pendingEvents = readPendingEvents();
+
+            if (!pendingEvents.length) {
+                renderEmptyState();
+                return;
+            }
+
+            pendingContainer.innerHTML = "";
+            pendingEvents.forEach(event => {
+                const instance = template.content.cloneNode(true);
+                instance.querySelector(".pending-event__title").textContent = event.name || "Untitled Event";
+                instance.querySelector('[data-field="display_date"]').textContent = event.display_date || "TBD";
+                instance.querySelector('[data-field="venue"]').textContent = event.venue_name ? `${event.venue_name}${event.venue_address ? ` • ${event.venue_address}` : ""}` : (event.venue_address || "TBD");
+                instance.querySelector('[data-field="category"]').textContent = event.category || "Uncategorized";
+                instance.querySelector('[data-field="summary"]').textContent = event.summary || "No summary provided.";
+                instance.querySelector('[data-field="description"]').textContent = event.description || "No description provided.";
+                instance.querySelector('[data-field="submitted_at"]').textContent = formatDate(event.submitted_at);
+                instance.querySelector('[data-field="price"]').textContent = event.is_free ? "Free" : "Paid/Unknown";
+
+                const openLink = instance.querySelector('[data-action="open"]');
+                openLink.href = event.url || "#";
+                openLink.textContent = event.url ? "Open event link" : "No link provided";
+                if (!event.url) {
+                    openLink.classList.add("disabled");
+                    openLink.setAttribute("aria-disabled", "true");
+                }
+
+                const article = instance.querySelector(".pending-event");
+
+                instance.querySelector('[data-action="copy"]').addEventListener("click", () => {
+                    if (!navigator.clipboard || !navigator.clipboard.writeText) {
+                        article.dataset.flash = "Clipboard unavailable";
+                        article.classList.add("flash-error");
+                        setTimeout(() => article.classList.remove("flash-error"), 700);
+                        return;
+                    }
+
+                    navigator.clipboard.writeText(JSON.stringify(event, null, 2))
+                        .then(() => {
+                            article.dataset.flash = "Copied!";
+                            article.classList.add("flash");
+                            setTimeout(() => article.classList.remove("flash"), 700);
+                        })
+                        .catch(err => {
+                            console.error("Copy failed", err);
+                            article.dataset.flash = "Copy failed";
+                            article.classList.add("flash-error");
+                            setTimeout(() => article.classList.remove("flash-error"), 700);
+                        });
+                });
+
+                instance.querySelector('[data-action="reviewed"]').addEventListener("click", () => {
+                    const updated = readPendingEvents().filter(item => item.id !== event.id);
+                    writePendingEvents(updated);
+                    renderPendingEvents();
+                });
+
+                pendingContainer.appendChild(instance);
+            });
+        }
+
+        exportButton.addEventListener("click", () => {
+            const pendingEvents = readPendingEvents();
+            const blob = new Blob([JSON.stringify(pendingEvents, null, 2)], { type: "application/json" });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement("a");
+            link.href = url;
+            link.download = "pending-events.json";
+            document.body.appendChild(link);
+            link.click();
+            link.remove();
+            URL.revokeObjectURL(url);
+        });
+
+        renderPendingEvents();
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -100,10 +100,10 @@
     
     <footer>
         <div class="container">
-            <p>© 2025 Boston Black Events Guide | <a href="#">About</a> | <a href="#">Contact</a> | <a href="submit-event.html">Submit an Event</a></p>
+            <p>© 2025 Boston Black Events Guide | <a href="#">About</a> | <a href="#">Contact</a> | <a href="submit-event.html">Submit an Event</a> | <a href="admin.html">Admin Dashboard</a></p>
         </div>
     </footer>
-    
+
     <script src="script.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -226,6 +226,12 @@ button {
     margin-right: 0.5rem;
 }
 
+.form-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
 .event-form .submit-btn {
     background: #000;
     color: #fff;
@@ -241,6 +247,23 @@ button {
     background: #333;
 }
 
+.secondary-link {
+    color: var(--primary);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.secondary-link:hover,
+.secondary-link:focus {
+    text-decoration: underline;
+}
+
+.secondary-link.disabled {
+    color: #888;
+    pointer-events: none;
+    text-decoration: none;
+}
+
 small {
     display: block;
     margin-top: 0.25rem;
@@ -248,12 +271,128 @@ small {
     font-size: 0.875rem;
 }
 
+.notice-card {
+    background: #fff;
+    border-radius: 8px;
+    padding: 1.5rem;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.status-message {
+    margin-top: 1.5rem;
+    padding: 1rem;
+    border-radius: 6px;
+    font-weight: 600;
+}
+
+.status-message.success {
+    background-color: #d1f7c4;
+    color: #1b5e20;
+}
+
+.status-message.error {
+    background-color: #ffd7d7;
+    color: #8b0000;
+}
+
+.admin-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin: 2rem 0 1rem;
+}
+
+.pending-events {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.empty-state {
+    text-align: center;
+    padding: 2rem;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+}
+
+.pending-event {
+    background: #fff;
+    border-radius: 10px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+    padding: 1.5rem;
+    display: grid;
+    gap: 1rem;
+}
+
+.pending-event__summary dl {
+    display: grid;
+    gap: 0.35rem;
+    margin: 0;
+}
+
+.pending-event__summary dt {
+    font-weight: 600;
+    color: #555;
+}
+
+.pending-event__summary dd {
+    margin: 0;
+}
+
+.pending-event__details {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.pending-event__meta {
+    font-size: 0.9rem;
+    color: #555;
+}
+
+.pending-event__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.pending-event__actions .danger {
+    background: #c1121f;
+}
+
+.pending-event__actions .danger:hover {
+    background: #a00f1a;
+}
+
+.pending-event.flash::after,
+.pending-event.flash-error::after {
+    content: attr(data-flash);
+    display: inline-block;
+    margin-left: 0.75rem;
+    font-weight: 600;
+}
+
+.pending-event.flash::after {
+    color: #1b5e20;
+}
+
+.pending-event.flash-error::after {
+    color: #8b0000;
+}
+
 @media (max-width: 768px) {
     .events-container {
         grid-template-columns: 1fr;
     }
-    
+
     .form-group {
         flex-direction: column;
+    }
+
+    .admin-actions {
+        flex-direction: column;
+        align-items: flex-start;
     }
 }

--- a/submit-event.html
+++ b/submit-event.html
@@ -15,51 +15,56 @@
     </header>
     
     <div class="container">
-        <form id="eventForm" class="event-form">
+        <div class="notice-card">
+            <h2>How it works</h2>
+            <p>Complete the form below and your event submission will be saved locally in your browser. An organizer can then review and import it from the admin dashboard.</p>
+        </div>
+
+        <form id="eventForm" class="event-form" novalidate>
             <div class="form-group">
                 <label for="name">Event Name*</label>
-                <input type="text" id="name" required>
+                <input type="text" id="name" name="name" required>
             </div>
             
             <div class="form-group">
                 <label for="description">Description*</label>
-                <textarea id="description" required></textarea>
+                <textarea id="description" name="description" required></textarea>
             </div>
             
             <div class="form-group">
                 <label for="summary">Short Summary*</label>
-                <input type="text" id="summary" required>
+                <input type="text" id="summary" name="summary" required>
                 <small>This will appear on the event card (keep it brief).</small>
             </div>
             
             <div class="form-group">
                 <label for="display_date">Date & Time*</label>
-                <input type="text" id="display_date" placeholder="Sat, May 3 • 7:00 PM" required>
+                <input type="text" id="display_date" name="display_date" placeholder="Sat, May 3 • 7:00 PM" required>
             </div>
             
             <div class="form-group">
                 <label for="venue_name">Venue Name*</label>
-                <input type="text" id="venue_name" required>
+                <input type="text" id="venue_name" name="venue_name" required>
             </div>
             
             <div class="form-group">
                 <label for="venue_address">Venue Address*</label>
-                <input type="text" id="venue_address" required>
+                <input type="text" id="venue_address" name="venue_address" required>
             </div>
             
             <div class="form-group">
                 <label for="url">Event URL*</label>
-                <input type="url" id="url" required>
+                <input type="url" id="url" name="url" required>
             </div>
             
             <div class="form-group checkbox">
-                <input type="checkbox" id="is_free">
+                <input type="checkbox" id="is_free" name="is_free">
                 <label for="is_free">This event is free</label>
             </div>
             
             <div class="form-group">
                 <label for="category">Category*</label>
-                <select id="category" required>
+                <select id="category" name="category" required>
                     <option value="">Select...</option>
                     <option value="Music">Music</option>
                     <option value="Arts & Culture">Arts & Culture</option>
@@ -70,37 +75,87 @@
                 </select>
             </div>
             
-            <button type="submit" class="submit-btn">Submit Event</button>
+            <div class="form-actions">
+                <button type="submit" class="submit-btn">Submit Event</button>
+                <a class="secondary-link" href="admin.html">Go to Admin Dashboard</a>
+            </div>
         </form>
+        <div id="submissionMessage" class="status-message" role="status" aria-live="polite" hidden></div>
     </div>
-    
+
     <footer>
         <div class="container">
-            <p>© 2025 Boston Black Events Guide | <a href="index.html">Home</a> | <a href="#">About</a> | <a href="#">Contact</a></p>
+            <p>© 2025 Boston Black Events Guide | <a href="index.html">Home</a> | <a href="#">About</a> | <a href="#">Contact</a> | <a href="admin.html">Admin Dashboard</a></p>
         </div>
     </footer>
-    
+
     <script>
-        document.getElementById("eventForm").addEventListener("submit", function(e) {
+        const form = document.getElementById("eventForm");
+        const submissionMessage = document.getElementById("submissionMessage");
+
+        function getPendingEvents() {
+            try {
+                const stored = localStorage.getItem("pendingEvents");
+                return stored ? JSON.parse(stored) : [];
+            } catch (error) {
+                console.error("Unable to read pending events", error);
+                return [];
+            }
+        }
+
+        function savePendingEvents(events) {
+            try {
+                localStorage.setItem("pendingEvents", JSON.stringify(events));
+                return true;
+            } catch (error) {
+                console.error("Unable to save pending events", error);
+                return false;
+            }
+        }
+
+        form.addEventListener("submit", function(e) {
             e.preventDefault();
-            
+
+            if (!form.checkValidity()) {
+                form.reportValidity();
+                submissionMessage.textContent = "Please complete all required fields before submitting.";
+                submissionMessage.classList.remove("success");
+                submissionMessage.classList.add("error");
+                submissionMessage.hidden = false;
+                return;
+            }
+
+            const formData = new FormData(form);
             const newEvent = {
                 id: "event-" + Date.now(),
-                name: document.getElementById("name").value,
-                description: document.getElementById("description").value,
-                summary: document.getElementById("summary").value,
-                display_date: document.getElementById("display_date").value,
-                venue_name: document.getElementById("venue_name").value,
-                venue_address: document.getElementById("venue_address").value,
-                url: document.getElementById("url").value,
-                is_free: document.getElementById("is_free").checked,
-                category: document.getElementById("category").value
+                name: formData.get("name")?.trim() || "",
+                description: formData.get("description")?.trim() || "",
+                summary: formData.get("summary")?.trim() || "",
+                display_date: formData.get("display_date")?.trim() || "",
+                venue_name: formData.get("venue_name")?.trim() || "",
+                venue_address: formData.get("venue_address")?.trim() || "",
+                url: formData.get("url")?.trim() || "",
+                is_free: formData.get("is_free") === "on",
+                category: formData.get("category") || "",
+                submitted_at: new Date().toISOString()
             };
-            
-            // For now, log the JSON (you'll replace this with API/GitHub submission)
-            console.log("New Event:", JSON.stringify(newEvent, null, 2));
-            alert("Thank you! Your event has been submitted for review.");
-            this.reset();
+
+            const pendingEvents = getPendingEvents();
+            pendingEvents.push(newEvent);
+
+            if (savePendingEvents(pendingEvents)) {
+                submissionMessage.textContent = "Thank you! Your event has been saved. An admin can review it from the dashboard.";
+                submissionMessage.classList.remove("error");
+                submissionMessage.classList.add("success");
+                submissionMessage.hidden = false;
+                form.reset();
+                form.querySelector("#name").focus();
+            } else {
+                submissionMessage.textContent = "We couldn't save your submission. Please ensure your browser allows local storage and try again.";
+                submissionMessage.classList.remove("success");
+                submissionMessage.classList.add("error");
+                submissionMessage.hidden = false;
+            }
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add an admin dashboard to review, export, and approve locally stored event submissions
- enhance the public submission form with validation, local storage persistence, and status messaging
- update shared styles and navigation links to support the new submission workflow

## Testing
- npm test *(fails: project does not define an automated test suite yet)*

------
https://chatgpt.com/codex/tasks/task_e_6901cb33d78c8332a380c4a5c1e60efd